### PR TITLE
Post-launch: Obsidian community install docs + pnpm/action-setup v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -85,7 +85,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -265,7 +265,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -532,7 +532,7 @@ jobs:
 
       - name: Setup pnpm
         if: ${{ steps.ext_version.outputs.should_release == 'true' }}
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         if: ${{ steps.ext_version.outputs.should_release == 'true' }}

--- a/.github/workflows/theme-audit.yml
+++ b/.github/workflows/theme-audit.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/README.ja.md
+++ b/README.ja.md
@@ -27,7 +27,7 @@ HearthCode はコードUI向けのテーマファミリーです。核になる�
 1. VS Code Marketplace: <https://marketplace.visualstudio.com/items?itemName=hearth-code.hearth-theme>
 2. Open VSX 互換エディタ: <https://open-vsx.org/extension/hearth-code/hearth-theme>
 3. VS Code Quick Open: `ext install hearth-code.hearth-theme`
-4. Obsidian テーマ: <https://github.com/hearth-code/HearthTheme/releases>
+4. Obsidian: アプリ内の **設定 → 外観 → テーマ → 管理** から **HearthCode** を検索。ソース: <https://github.com/hearth-code/hearthcode-obsidian>
 
 ## 公開中のテーマ
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HearthCode is a theme family for code interfaces with two design directions: Emb
 1. VS Code Marketplace: <https://marketplace.visualstudio.com/items?itemName=hearth-code.hearth-theme>
 2. Open VSX-compatible editors: <https://open-vsx.org/extension/hearth-code/hearth-theme>
 3. VS Code Quick Open: `ext install hearth-code.hearth-theme`
-4. Obsidian Theme: <https://github.com/hearth-code/HearthTheme/releases>
+4. Obsidian: in-app **Settings → Appearance → Themes → Manage**, then search **HearthCode**. Source: <https://github.com/hearth-code/hearthcode-obsidian>
 
 ## Shipped Themes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ HearthCode 是一套面向代码界面的主题家族，核心只有两条设计
 1. VS Code Marketplace：<https://marketplace.visualstudio.com/items?itemName=hearth-code.hearth-theme>
 2. Open VSX 兼容编辑器：<https://open-vsx.org/extension/hearth-code/hearth-theme>
 3. VS Code 快速安装：`ext install hearth-code.hearth-theme`
-4. Obsidian 主题：<https://github.com/hearth-code/HearthTheme/releases>
+4. Obsidian：应用内 **设置 → 外观 → 主题 → 管理**，搜索 **HearthCode**。源仓库：<https://github.com/hearth-code/hearthcode-obsidian>
 
 ## 当前主题
 


### PR DESCRIPTION
Two small post-launch housekeeping changes:

- **docs**: HearthCode is now in the Obsidian community theme directory (published from `hearth-code/hearthcode-obsidian`). Update the Obsidian install step in all three README locales from the stale 'download from releases' link to in-app install (Settings → Appearance → Themes → Manage → search HearthCode). Copy-sync audit passes.
- **ci**: bump `pnpm/action-setup` v4 → v6 across both workflows to clear the Node 20 runtime deprecation warning (matches the actions/* already on v6).