### PR TITLE
Automate Obsidian mirror publish in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -441,6 +441,43 @@ jobs:
           --baseImagesUrl "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/extension"
           -p "${OVSX_PAT}"
 
+  publish-obsidian:
+    runs-on: ubuntu-latest
+    needs: verify
+    env:
+      OBSIDIAN_PUBLISH_TOKEN: ${{ secrets.OBSIDIAN_PUBLISH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Skip publish (no Obsidian token)
+        if: ${{ env.OBSIDIAN_PUBLISH_TOKEN == '' }}
+        run: echo "OBSIDIAN_PUBLISH_TOKEN is missing. Skipping Obsidian mirror publish."
+
+      # Mirrors the committed obsidian/app-theme/* (verify already gates them via
+      # check:sync) to the dedicated publish repo's default-branch root, which is
+      # where Obsidian reads community themes from. Idempotent: the script skips
+      # the push when nothing changed and skips the release when the tag exists,
+      # so this is safe to run on every push to main.
+      - name: Publish to Obsidian mirror
+        if: ${{ env.OBSIDIAN_PUBLISH_TOKEN != '' }}
+        run: >
+          node scripts/pack-obsidian-publish.mjs
+          --repo hearth-code/hearthcode-obsidian
+          --release
+          --no-generate
+
   release-github:
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/pack-obsidian-publish.mjs
+++ b/scripts/pack-obsidian-publish.mjs
@@ -56,6 +56,16 @@ function commandExists(command) {
   return probe.status === 0
 }
 
+// Local dev pushes over SSH (git@github.com). CI provides a token with push
+// access to the publish repo via OBSIDIAN_PUBLISH_TOKEN; when present we clone /
+// push over HTTPS with that token and reuse it for the `gh release` call, so a
+// single fine-grained PAT (contents:write on the mirror) covers everything.
+function remoteUrlFor(repo, token) {
+  return token
+    ? `https://x-access-token:${token}@github.com/${repo}.git`
+    : `git@github.com:${repo}.git`
+}
+
 function prepareAppTheme() {
   runStep('node', ['scripts/generate-theme-variants.mjs'], 'generate-theme-variants')
   runStep('node', ['scripts/generate-obsidian-themes.mjs'], 'generate-obsidian-themes')
@@ -82,10 +92,10 @@ function ensureSupportingFiles(cloneDir) {
   }
 }
 
-function ensureRelease(cloneDir, repo, version) {
+function ensureRelease(cloneDir, repo, version, token = '') {
   const tag = String(version)
   // Already released?
-  const existing = git(['ls-remote', '--tags', `git@github.com:${repo}.git`, tag], { allowFail: true })
+  const existing = git(['ls-remote', '--tags', remoteUrlFor(repo, token), tag], { allowFail: true })
   if (existing.status === 0 && existing.stdout.includes(`refs/tags/${tag}`)) {
     console.log(`[publish] release tag ${tag} already exists — skipping`)
     return
@@ -96,7 +106,7 @@ function ensureRelease(cloneDir, repo, version) {
     const result = spawnSync(
       'gh',
       ['release', 'create', tag, '--repo', repo, '--title', tag, '--notes', `HearthCode ${tag}`, ...assets],
-      { stdio: 'inherit' },
+      { stdio: 'inherit', env: token ? { ...process.env, GH_TOKEN: token } : process.env },
     )
     if (result.status !== 0) throw new Error('gh release create failed')
     console.log(`[publish] created GitHub release ${tag}`)
@@ -117,6 +127,7 @@ function main() {
   const skipGenerate = hasFlag('--no-generate')
   const doRelease = hasFlag('--release')
 
+  const token = process.env.OBSIDIAN_PUBLISH_TOKEN || ''
   const version = getReleaseVersion()
 
   if (!skipGenerate) {
@@ -129,12 +140,12 @@ function main() {
     }
   }
 
-  const sshUrl = `git@github.com:${repo}.git`
+  const remoteUrl = remoteUrlFor(repo, token)
   const cloneDir = resolve(WORK_ROOT, repo.replace(/[/]/g, '__'))
 
   mkdirSync(WORK_ROOT, { recursive: true })
   rmSync(cloneDir, { recursive: true, force: true })
-  git(['clone', '--quiet', '--depth', '1', sshUrl, cloneDir])
+  git(['clone', '--quiet', '--depth', '1', remoteUrl, cloneDir])
 
   const branch =
     git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: cloneDir, allowFail: true }).stdout || DEFAULT_BRANCH
@@ -155,7 +166,7 @@ function main() {
 
   if (!status) {
     console.log(`[publish] ${repo} already up to date for ${version} — nothing to push.`)
-    if (doRelease) ensureRelease(cloneDir, repo, version)
+    if (doRelease) ensureRelease(cloneDir, repo, version, token)
     return
   }
 
@@ -177,7 +188,7 @@ function main() {
   git(['push', 'origin', branch], { cwd: cloneDir })
   console.log(`[publish] pushed HearthCode ${version} to ${repo} (${branch}).`)
 
-  if (doRelease) ensureRelease(cloneDir, repo, version)
+  if (doRelease) ensureRelease(cloneDir, repo, version, token)
 }
 
 try {


### PR DESCRIPTION
## What

Adds a `publish-obsidian` job to the Main Release Pipeline so the Obsidian community-theme mirror (`hearth-code/hearthcode-obsidian`) publishes automatically on every push to `main`, alongside the existing **Marketplace**, **Open VSX**, and **GitHub release** targets. This closes the one release channel that still required a manual `pnpm run release:obsidian:publish` after each version bump.

## How

- **`scripts/pack-obsidian-publish.mjs`**: when `OBSIDIAN_PUBLISH_TOKEN` is set, clone/push and `gh release create` over HTTPS using that token; otherwise fall back to the existing SSH path for local dev. One fine-grained PAT covers both git push and the release object.
- **`.github/workflows/publish.yml`**: new `publish-obsidian` job (`needs: verify`), token-gated (skips cleanly when the secret is absent), runs `pack-obsidian-publish.mjs --release --no-generate` against the committed `obsidian/app-theme/*` (already gated by `check:sync` in `verify`). The script is idempotent — no push when files are unchanged, skips the release when the tag exists — so it is safe to run on every main push.

## One-time setup required before this auto-publishes

Add a repo secret **`OBSIDIAN_PUBLISH_TOKEN`** — a fine-grained PAT scoped to `hearth-code/hearthcode-obsidian` with **Contents: read & write**. Until that secret exists, the job runs but cleanly skips (logs "OBSIDIAN_PUBLISH_TOKEN is missing").

## Notes

- Zero generated-output drift; `verify` passes locally.
- 3.4.1 is already live on the mirror (hand-synced); this just removes the manual step going forward.