### PR TITLE
Fix Obsidian mirror publish: set git identity for the sync commit

### DIFF
--- a/scripts/pack-obsidian-publish.mjs
+++ b/scripts/pack-obsidian-publish.mjs
@@ -178,7 +178,15 @@ function main() {
     return
   }
 
-  git(['-c', 'commit.gpgsign=false', 'commit', '-m', `Sync HearthCode ${version}`], { cwd: cloneDir })
+  git(
+    [
+      '-c', 'user.name=github-actions[bot]',
+      '-c', 'user.email=41898282+github-actions[bot]@users.noreply.github.com',
+      '-c', 'commit.gpgsign=false',
+      'commit', '-m', `Sync HearthCode ${version}`,
+    ],
+    { cwd: cloneDir },
+  )
 
   if (noPush) {
     console.log(`[publish] committed in work clone (${cloneDir}); --no-push set, not pushing.`)


### PR DESCRIPTION
The `publish-obsidian` job in the 3.5.0 release run failed with `fatal: empty ident name not allowed` — the runner has no git user and `pack-obsidian-publish.mjs` commits in the mirror clone without one. Pass `-c user.name/user.email` (github-actions[bot]) on the commit. 3.5.0 is already live on VS Marketplace, Open VSX, and the GitHub Release; merging this completes the Obsidian community-mirror sync (idempotent re-run).