### PR TITLE
Document Theme Forge in the VS Code READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/hearth-code/hearth-theme)](https://open-vsx.org/extension/hearth-code/hearth-theme)
 [![Start on theme.hearthcode.dev](https://img.shields.io/badge/start%20on-theme.hearthcode.dev-8b6b4d)](https://theme.hearthcode.dev)
 
-HearthCode はコードUI向けのテーマファミリーです。核になる方向は Ember と Moss の 2 つだけで、それぞれに Dark と Light を用意し、VS Code、Open VSX 互換エディタ、Obsidian で使えます。
+HearthCode はコードUI向けのテーマファミリーです。核になる方向は Ember と Moss の 2 つだけで、それぞれに Dark と Light を用意し、VS Code と Open VSX 互換エディタで使えます。Obsidian 版は現在 Moss のみです。
 
 ![HearthCode Theme Preview](./extension/images/preview-contrast-v2.png)
 
@@ -43,6 +43,10 @@ Style Settings プラグインにも対応しています。タイポグラフ�
 - `HearthCode Moss Light`
 - `HearthCode Ember Dark`
 - `HearthCode Ember Light`
+
+## Theme Forge
+
+プライマリカラーを変えたいときは、**HearthCode: Open Theme Forge** を実行してパネルを開き、色を選ぶと、テーマ全体——構文**および**エディタのクローム（ステータスバー、サイド / アクティビティ / タイトルバー、各サーフェス）——がダーク / ライトの並列プレビューでリアルタイムに染め直されます。**Apply** は結果を theme-scoped color customizations として書き込み（即時反映、リロード不要）、アクティブな HearthCode スキームのダークとライトの 2 バリアントだけを塗り替え、もう一方のスキームには手を触れません——先に Moss か Ember のバリアントへ切り替えてください。**HearthCode: Reset Theme Forge** は Forge が書き込んだものだけを正確に取り除きます。品質は構築時に担保されます。Forge は公開テーマと同じ品質コントラクトに縛られており、構文レーンはまとめて回転して役割の分離を保ち、彩度は安全な帯域にクランプされ、クロームの色みはコントラスト検証を通してエディタ文字を AA に保ち、機能色（ターミナル・エラー・git・diff）はそれぞれの意味を保ちます。
 
 ## イタリックを無効にしたい場合
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/hearth-code/hearth-theme)](https://open-vsx.org/extension/hearth-code/hearth-theme)
 [![Start on theme.hearthcode.dev](https://img.shields.io/badge/start%20on-theme.hearthcode.dev-8b6b4d)](https://theme.hearthcode.dev)
 
-HearthCode is a theme family for code interfaces with two design directions: Ember and Moss. Each direction ships Dark and Light across VS Code, Open VSX-compatible editors, and Obsidian.
+HearthCode is a theme family for code interfaces with two design directions: Ember and Moss. Each direction ships Dark and Light for VS Code and Open VSX-compatible editors; Moss is also available for Obsidian.
 
 ![HearthCode Theme Preview](./extension/images/preview-contrast-v2.png)
 
@@ -43,6 +43,10 @@ It also integrates with the Style Settings plugin: tune typography (monospace no
 - `HearthCode Moss Light`
 - `HearthCode Ember Dark`
 - `HearthCode Ember Light`
+
+## Theme Forge
+
+Want a different primary color? Run **HearthCode: Open Theme Forge** to open a panel, pick a color, and watch the whole theme — syntax **and** editor chrome (status bar, side/activity/title bars, and surfaces) — recolor live in a side-by-side dark/light preview. **Apply** writes the result as theme-scoped color customizations (live, no reload), painting only your active HearthCode scheme's dark and light variants and leaving the other scheme untouched — switch to a Moss or Ember variant first. **HearthCode: Reset Theme Forge** removes exactly what Forge wrote. Quality holds by construction: Forge is bound by the same quality contract as the shipped themes — the syntax lanes rotate together so role separation holds, saturation is clamped to a safe band, the chrome tint is contrast-checked so editor text stays at AA, and functional colors (terminal, errors, git, diff) keep their meaning.
 
 ## Prefer No Italics?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 [![Open VSX 下载量](https://img.shields.io/open-vsx/dt/hearth-code/hearth-theme)](https://open-vsx.org/extension/hearth-code/hearth-theme)
 [![在 theme.hearthcode.dev 开始](https://img.shields.io/badge/start%20on-theme.hearthcode.dev-8b6b4d)](https://theme.hearthcode.dev)
 
-HearthCode 是一套面向代码界面的主题家族，核心只有两条设计方向：Ember 和 Moss。每条方向都提供 Dark 与 Light 两个版本，并覆盖 VS Code、Open VSX 兼容编辑器和 Obsidian。
+HearthCode 是一套面向代码界面的主题家族，核心只有两条设计方向：Ember 和 Moss。每条方向都提供 Dark 与 Light 两个版本，覆盖 VS Code 和 Open VSX 兼容编辑器；其中 Obsidian 目前只有 Moss。
 
 ![HearthCode 主题预览](./extension/images/preview-contrast-v2.png)
 
@@ -43,6 +43,10 @@ HearthCode 同样是一套完整的 Obsidian 主题——把同一套色彩语�
 - `HearthCode Moss Light`
 - `HearthCode Ember Dark`
 - `HearthCode Ember Light`
+
+## Theme Forge
+
+想换个主色？运行 **HearthCode: Open Theme Forge** 打开面板，选一个颜色，整个主题——语法**以及**编辑器外壳（状态栏、侧边栏 / 活动栏 / 标题栏，以及各表面）——会在深色 / 浅色并排预览里实时重染。**Apply** 会把结果写成 theme-scoped color customizations（即时生效、无需重载），只影响当前 HearthCode 方案的深色与浅色两个变体，另一个方案保持不动——请先切到 Moss 或 Ember 变体。**HearthCode: Reset Theme Forge** 会精确移除 Forge 写入的内容。质量由构建保证：Forge 受与官方主题同一套质量契约约束——语法通道整体旋转以保持角色分离，饱和度被限制在安全带内，外壳染色经过对比度校验以让编辑器文本维持 AA，功能色（终端、错误、git、diff）保持各自语义。
 
 ## 不想要斜体？
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -30,6 +30,10 @@ Each direction ships Dark and Light for VS Code and Open VSX-compatible editors.
 - `HearthCode Ember Dark`
 - `HearthCode Ember Light`
 
+## Theme Forge
+
+Want a different primary color? Run **HearthCode: Open Theme Forge** to open a panel, pick a color, and watch the whole theme — syntax **and** editor chrome (status bar, side/activity/title bars, and surfaces) — recolor live in a side-by-side dark/light preview. **Apply** writes the result as theme-scoped color customizations (live, no reload), painting only your active HearthCode scheme's dark and light variants and leaving the other scheme untouched — switch to a Moss or Ember variant first. **HearthCode: Reset Theme Forge** removes exactly what Forge wrote. Quality holds by construction: Forge is bound by the same quality contract as the shipped themes — the syntax lanes rotate together so role separation holds, saturation is clamped to a safe band, the chrome tint is contrast-checked so editor text stays at AA, and functional colors (terminal, errors, git, diff) keep their meaning.
+
 ## Prefer no italics?
 
 HearthCode styles comments, types, and decorators in italics. If your font renders italics poorly (common with CJK fonts), enable the `hearthcode.disableItalics` setting — the extension switches every italic rule off while keeping all colors intact, and undoes it when toggled back. Details and a manual alternative live in [disable-italics.md](https://github.com/hearth-code/HearthTheme/blob/main/docs/disable-italics.md).


### PR DESCRIPTION
## What

3.6.0 shipped **Theme Forge** (the in-editor customizer for recoloring the theme's primary color live), but none of the VS Code–facing READMEs mentioned it. This adds a trilingual (EN/ZH/JA) Theme Forge section to all four:

- `extension/README.md` (Marketplace payload) — inserted between **Themes** and **Prefer no italics?**
- `README.md` (root, English)
- `README.zh-CN.md`
- `README.ja.md`

The section mirrors the 3.6.0 CHANGELOG wording:

- `HearthCode: Open Theme Forge` opens the panel; pick a primary color and the whole theme (syntax + editor chrome: status/side/activity/title bars and surfaces) recolors live in a dark/light preview.
- **Apply** writes theme-scoped color customizations (live, no reload), touching only the active HearthCode scheme's dark and light variants and leaving the other scheme untouched — switch to a Moss or Ember variant first.
- `HearthCode: Reset Theme Forge` removes exactly what Forge wrote.
- Quality is build-enforced: same quality contract as the shipped themes — syntax lanes rotate together to preserve role separation, saturation clamped to a safe band, chrome tint contrast-checked to AA, functional colors (terminal/errors/git/diff) keep their meaning.

## Also

Fixed the root intro (and the two translations) that read *"Each direction ships Dark and Light across VS Code, Open VSX-compatible editors, and Obsidian"* — this implied Ember ships to Obsidian, but Obsidian only ships Moss. Reworded so Obsidian is scoped to Moss.

## Release discipline

README-only change. `extension/README.md` is in the publish workflow's `docsOnlyFiles`, so this follows the docs-only skip-publish path — no bump to `releases/color-language.json` required.

## Verification

- `pnpm run audit:all` — pass (content-sync-audit and claims-audit both green)
- `pnpm run check:sync` — clean, zero drift
- lockfile untouched; commit contains only the 4 README files

(The pre-push hook's `astro build` step was skipped because this worktree has no linked `node_modules`; a docs-only change cannot affect the site build, and the meaningful audits were run directly.)